### PR TITLE
Shvaich commands help patch 1

### DIFF
--- a/src/main/java/fr/alexdoru/mwe/commands/MyAbstractCommand.java
+++ b/src/main/java/fr/alexdoru/mwe/commands/MyAbstractCommand.java
@@ -60,7 +60,7 @@ public abstract class MyAbstractCommand extends CommandBase {
      * @param commandLines Each command-line must be in this format: { command, description, [commandToPutOnClick] }.
      *                     if (commandToPutOnClick) isn't provided will use (command)
      */
-    private static void printCommandHelpBlock(String header, String[][] commandLines) {
+    protected static void printCommandHelpBlock(String header, String[][] commandLines) {
         ChatUtil.addChatMessage(new ChatComponentText(ChatUtil.centerLine(EnumChatFormatting.GOLD + header)));
         for (final String[] line : commandLines) {
             if (line.length!=2) continue;

--- a/src/main/java/fr/alexdoru/mwe/commands/MyAbstractCommand.java
+++ b/src/main/java/fr/alexdoru/mwe/commands/MyAbstractCommand.java
@@ -63,13 +63,13 @@ public abstract class MyAbstractCommand extends CommandBase {
     protected static void printCommandHelpBlock(String header, String[][] commandLines) {
         ChatUtil.addChatMessage(new ChatComponentText(ChatUtil.centerLine(EnumChatFormatting.GOLD + header)));
         for (final String[] line : commandLines) {
-            if (line.length!=2) continue;
             final String command = line[0];
             final String desc = line[1];
+            final String commandToPutOnClick = line.length == 3 ? line[2] : command;
             ChatUtil.addChatMessage(new ChatComponentText(EnumChatFormatting.YELLOW + command + EnumChatFormatting.GRAY + " - " + EnumChatFormatting.AQUA + desc)
                     .setChatStyle(new ChatStyle()
                             .setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ChatComponentText(EnumChatFormatting.GRAY + "Click to put the command in chat.")))
-                            .setChatClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, command)))
+                            .setChatClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, commandToPutOnClick)))
             );
         }
     }


### PR DESCRIPTION
This is a patch to the merged `commands_help` branch.
this patch is to help other developers who want to create their own MWEAddon.
each change in this patch is something that I am counting on to be available to my MoreMWE addon.

I need `printCommandHelpBlock(String, String[][])` to also be available to inheritors, I use it for my `/play` help blocks.
I need `printCommandHelpBlock(String, String[][])` to be able to proccess `lines` with the optional `commandToPutOnClick` argument.

Example:
```{ "/friend bulk <player> [<player>...]", "Repeats the command for each specified player", "/friend bulk" }```

Will print:
`/friend bulk <player> [<player>...] - Repeats the command for each specified player`

On click will paste: `/friend bulk` to the `textbox` instead of `/friend bulk <player> [<player>...]`

---
And still this:
```{ "/squad add <player>", "add a player to the squad" }```

Will print:
`/squad add <player> - add a player to the squad`

And on click will paste `/squad add <player>` to the `textbox`