### PR TITLE
Add vertical mini potion HUD option and match fake player count color

### DIFF
--- a/src/main/java/fr/alexdoru/mwe/asm/hooks/mc/gui/GuiPlayerTabOverlayHook_PlayerCount.java
+++ b/src/main/java/fr/alexdoru/mwe/asm/hooks/mc/gui/GuiPlayerTabOverlayHook_PlayerCount.java
@@ -32,7 +32,7 @@ public class GuiPlayerTabOverlayHook_PlayerCount {
                     nicks++;
                 }
             }
-            list.add(GREEN + "Players: " + GOLD + i + (nicks == 0 ? "" : WHITE + " (" + GOLD + nicks + WHITE + ")"));
+            list.add(GREEN + "Players: " + GOLD + i + (nicks == 0 ? "" : WHITE + " (" + DARK_RED + nicks + WHITE + ")"));
         } else {
             list.add(GREEN + "Players: " + GOLD + i);
         }

--- a/src/main/java/fr/alexdoru/mwe/config/MWEConfig.java
+++ b/src/main/java/fr/alexdoru/mwe/config/MWEConfig.java
@@ -436,6 +436,13 @@ public final class MWEConfig {
 
     @ConfigProperty(
             category = PVP_STUFF, subCategory = "Potion HUD",
+            name = "Vertical Mini Potion HUD",
+            dependsOn = "Mini Potion HUD",
+            comment = "Displays the Mini Potion HUD vertically")
+    public static boolean verticalMiniPotionHUD;
+
+    @ConfigProperty(
+            category = PVP_STUFF, subCategory = "Potion HUD",
             name = "Mini Potion HUD only in MW",
             dependsOn = "Mini Potion HUD",
             comment = "Displays the mini potion HUD only in Mega Walls")

--- a/src/main/java/fr/alexdoru/mwe/gui/huds/MiniPotionHUD.java
+++ b/src/main/java/fr/alexdoru/mwe/gui/huds/MiniPotionHUD.java
@@ -62,10 +62,23 @@ public class MiniPotionHUD extends AbstractRenderer {
             count++;
         }
         len -= 2;
-        int x = this.rendererPosition.getAbsoluteRenderX() - len / 2;
-        for (int i = 0; i < count; i++) {
-            mc.fontRendererObj.drawStringWithShadow(strings[i], x, this.rendererPosition.getAbsoluteRenderY(), colors[i]);
-            x += mc.fontRendererObj.getStringWidth(strings[i]) + 2;
+        if (MWEConfig.verticalMiniPotionHUD) {
+            int x = this.rendererPosition.getAbsoluteRenderX();
+            int y = this.rendererPosition.getAbsoluteRenderY();
+            final int maxY = resolution.getScaledHeight() - count * mc.fontRendererObj.FONT_HEIGHT;
+            if (y > maxY) {
+                y = maxY;
+            }
+            for (int i = 0; i < count; i++) {
+                mc.fontRendererObj.drawStringWithShadow(strings[i], x - mc.fontRendererObj.getStringWidth(strings[i]) / 2, y, colors[i]);
+                y += mc.fontRendererObj.FONT_HEIGHT;
+            }
+        } else {
+            int x = this.rendererPosition.getAbsoluteRenderX() - len / 2;
+            for (int i = 0; i < count; i++) {
+                mc.fontRendererObj.drawStringWithShadow(strings[i], x, this.rendererPosition.getAbsoluteRenderY(), colors[i]);
+                x += mc.fontRendererObj.getStringWidth(strings[i]) + 2;
+            }
         }
     }
 

--- a/src/main/java/fr/alexdoru/mwe/gui/huds/MiniPotionHUD.java
+++ b/src/main/java/fr/alexdoru/mwe/gui/huds/MiniPotionHUD.java
@@ -65,13 +65,13 @@ public class MiniPotionHUD extends AbstractRenderer {
         if (MWEConfig.verticalMiniPotionHUD) {
             int x = this.rendererPosition.getAbsoluteRenderX();
             int y = this.rendererPosition.getAbsoluteRenderY();
-            final int maxY = resolution.getScaledHeight() - count * mc.fontRendererObj.FONT_HEIGHT;
+            final int maxY = resolution.getScaledHeight() - count * (mc.fontRendererObj.FONT_HEIGHT + 2);
             if (y > maxY) {
                 y = maxY;
             }
             for (int i = 0; i < count; i++) {
                 mc.fontRendererObj.drawStringWithShadow(strings[i], x - mc.fontRendererObj.getStringWidth(strings[i]) / 2, y, colors[i]);
-                y += mc.fontRendererObj.FONT_HEIGHT;
+                y += mc.fontRendererObj.FONT_HEIGHT + 2;
             }
         } else {
             int x = this.rendererPosition.getAbsoluteRenderX() - len / 2;

--- a/src/main/java/fr/alexdoru/mwe/gui/huds/MiniPotionHUD.java
+++ b/src/main/java/fr/alexdoru/mwe/gui/huds/MiniPotionHUD.java
@@ -61,22 +61,24 @@ public class MiniPotionHUD extends AbstractRenderer {
             len += mc.fontRendererObj.getStringWidth(strings[count]) + 2;
             count++;
         }
+        if (count == 0) return;
         len -= 2;
         if (MWEConfig.verticalMiniPotionHUD) {
-            int x = this.rendererPosition.getAbsoluteRenderX();
+            final int x = this.rendererPosition.getAbsoluteRenderX();
             int y = this.rendererPosition.getAbsoluteRenderY();
             final int maxY = resolution.getScaledHeight() - count * (mc.fontRendererObj.FONT_HEIGHT + 2);
             if (y > maxY) {
                 y = maxY;
             }
             for (int i = 0; i < count; i++) {
-                mc.fontRendererObj.drawStringWithShadow(strings[i], x - mc.fontRendererObj.getStringWidth(strings[i]) / 2, y, colors[i]);
+                mc.fontRendererObj.drawStringWithShadow(strings[i], x - mc.fontRendererObj.getStringWidth(strings[i]) / 2F, y, colors[i]);
                 y += mc.fontRendererObj.FONT_HEIGHT + 2;
             }
         } else {
             int x = this.rendererPosition.getAbsoluteRenderX() - len / 2;
+            final int y = this.rendererPosition.getAbsoluteRenderY();
             for (int i = 0; i < count; i++) {
-                mc.fontRendererObj.drawStringWithShadow(strings[i], x, this.rendererPosition.getAbsoluteRenderY(), colors[i]);
+                mc.fontRendererObj.drawStringWithShadow(strings[i], x, y, colors[i]);
                 x += mc.fontRendererObj.getStringWidth(strings[i]) + 2;
             }
         }


### PR DESCRIPTION
Adds a "Vertical Mini Potion HUD" toggle in the Potion HUD settings. When on, the mini potion HUD stacks vertically — one effect per line, centered — instead of the usual single horizontal line.
The fake player count in the tab header now uses dark red, matching the red star next to fake player names.

Vertical Mini Potion HUD UI :
<img width="1392" height="812" alt="3" src="https://github.com/user-attachments/assets/63c67670-9ac3-4cda-a7e2-b86204ea699d" />

Mini Potion HUD (horizontal) :
<img width="518" height="296" alt="1" src="https://github.com/user-attachments/assets/51be841e-a257-429e-bf80-588229b5eec6" />

Mini Potion HUD (vertical) :
<img width="627" height="392" alt="5" src="https://github.com/user-attachments/assets/fd3e8020-66c4-4813-8ad9-e0117dba5f17" />

The fake player count :
<img width="374" height="60" alt="4" src="https://github.com/user-attachments/assets/bd8edadb-0e9c-4daf-9a3e-258a1e460203" />
