### PR TITLE
Visual Fix to command-help-message

### DIFF
--- a/src/main/java/fr/alexdoru/mwe/api/MWECommandBase.java
+++ b/src/main/java/fr/alexdoru/mwe/api/MWECommandBase.java
@@ -61,7 +61,7 @@ public abstract class MWECommandBase extends CommandBase {
      *                     if (commandToPutOnClick) isn't provided will use (command)
      */
     protected static void printCommandHelpBlock(String header, String[][] commandLines) {
-        ChatUtil.addChatMessage(new ChatComponentText(ChatUtil.centerLine(EnumChatFormatting.GOLD + header)));
+        ChatUtil.addChatMessage(new ChatComponentText(ChatUtil.centerLine(EnumChatFormatting.GOLD + header + "\n")));
         for (final String[] line : commandLines) {
             if (line.length < 2) continue;
             final String command = line[0];

--- a/src/main/java/fr/alexdoru/mwe/api/MWECommandBase.java
+++ b/src/main/java/fr/alexdoru/mwe/api/MWECommandBase.java
@@ -61,7 +61,8 @@ public abstract class MWECommandBase extends CommandBase {
      *                     if (commandToPutOnClick) isn't provided will use (command)
      */
     protected static void printCommandHelpBlock(String header, String[][] commandLines) {
-        ChatUtil.addChatMessage(new ChatComponentText(ChatUtil.centerLine(EnumChatFormatting.GOLD + header + "\n")));
+        ChatUtil.addChatMessage(new ChatComponentText(ChatUtil.centerLine(EnumChatFormatting.GOLD + header)));
+        ChatUtil.addChatMessage("");
         for (final String[] line : commandLines) {
             if (line.length < 2) continue;
             final String command = line[0];


### PR DESCRIPTION
added a new line after the command help header.
this is so there will be some space between the help header and the command examples. (this is how it looked previously)